### PR TITLE
fix: add trailing slashes to routes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,5 +46,6 @@
     "react/jsx-no-literals": "off",
 
     "jsx-a11y/anchor-is-valid": "off"
-  }
+  },
+  "ignorePatterns": ["next-env.d.ts", "next.config.js"]
 }

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@
 const nextConfig = {
   root: true,
   reactStrictMode: true,
+  trailingSlash: true,
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
# Description
Trailing slashes are needed for static exports, so we can rely on index.html files instead of files with html extensions